### PR TITLE
Implement a release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: release
+
+on:
+  push:
+    # run only against tags
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.3'
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ bin/
 .idea
 *.log
 tmp/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/secops-chaos
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.GitCommit={{.Commit}}"
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.Version={{.Version}}"
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.BuildDate={{ .Date }}"
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/README.md
+++ b/README.md
@@ -30,11 +30,17 @@
 
 ### Installation
 
-``` sh
-go install github.com/operantai/secops-chaos/cmd/secops-chaos@latest
-```
+You can fetch the latest release [here][latest-release-url], or you can build from source.
 
-Go will automatically install it in your `$GOPATH/bin` directory, which should be in your `$PATH`.
+#### Building from Source
+
+To build from source, you'll need to have [Go](https://golang.org/) installed.
+
+```sh
+git clone https://github.com/operantai/secops-chaos
+cd secops-chaos
+make build
+```
 
 ### Usage
 
@@ -69,6 +75,7 @@ Please read the contribution guidelines, [here][contributing-url].
 
 Distributed under the [Apache License 2.0][license-url].
 
+[latest-release-url]: https://github.com/operantai/secops-chaos/releases/latest
 [experiments-dir-url]: https://github.com/operantai/secops-chaos/blob/main/experiments
 [contributing-url]: https://github.com/operantai/secops-chaos/blob/main/CONTRIBUTING.md
 [license-url]: https://github.com/operantai/secops-chaos/blob/main/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.21.3
 
 require (
 	github.com/charmbracelet/lipgloss v0.9.1
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,6 @@ github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
Implements a release process using [GoReleaser](https://goreleaser.com/), when a new tag is pushed, it cuts a release using a GHA and generates binaries which are available under the releases page.