### PR TITLE
Improving structured output to support YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Once you've successfully run the experiment, you can verify if it was sucessful 
 secops-chaos experiment verify -f experiments/host_path_volume.yaml
 ```
 
-You can also output a JSON with the verifier results by using the `-j` flag.
+You can also output in various formats using `-o json` or `-o yaml`
 
 #### Components
 

--- a/cmd/secops-chaos/cmd/experiment.go
+++ b/cmd/secops-chaos/cmd/experiment.go
@@ -44,7 +44,7 @@ var verifyCmd = &cobra.Command{
 		if err != nil {
 			output.WriteError("Error reading file flag: %v", err)
 		}
-		outputJSON, err := cmd.Flags().GetBool("json")
+		outputFormat, err := cmd.Flags().GetString("output")
 		if err != nil {
 			output.WriteError("Error reading json output flag: %v", err)
 		}
@@ -52,7 +52,7 @@ var verifyCmd = &cobra.Command{
 		// Run the verifiers
 		ctx := cmd.Context()
 		er := experiments.NewRunner(ctx, files)
-		er.RunVerifiers(outputJSON)
+		er.RunVerifiers(outputFormat)
 	},
 }
 
@@ -91,5 +91,5 @@ func init() {
 	_ = cleanCmd.MarkFlagRequired("file")
 
 	// Output the results in JSON format
-	verifyCmd.Flags().BoolP("json", "j", false, "Output results in JSON format")
+	verifyCmd.Flags().StringP("output", "o", "", "Output results in provided format (json|yaml)")
 }

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -5,6 +5,7 @@ package experiments
 
 import (
 	"context"
+	"strings"
 
 	"github.com/operantai/secops-chaos/internal/k8s"
 	"github.com/operantai/secops-chaos/internal/output"
@@ -94,7 +95,7 @@ func (r *Runner) Run() {
 }
 
 // RunVerifiers runs all verifiers in the Runner for the provided experiments
-func (r *Runner) RunVerifiers(writeJSON bool) {
+func (r *Runner) RunVerifiers(outputFormat string) {
 	table := output.NewTable([]string{"Experiment", "Description", "Framework", "Tactic", "Technique", "Result"})
 	outcomes := []*verifier.Outcome{}
 	for _, e := range r.experimentsConfig {
@@ -104,7 +105,7 @@ func (r *Runner) RunVerifiers(writeJSON bool) {
 			output.WriteFatal("Verifier %s failed: %s", e.Metadata.Name, err)
 		}
 		// if JSON flag is set, append to JSON output
-		if writeJSON {
+		if outputFormat != "" {
 			outcomes = append(outcomes, outcome)
 		} else {
 			table.AddRow([]string{
@@ -118,16 +119,24 @@ func (r *Runner) RunVerifiers(writeJSON bool) {
 		}
 	}
 
-	// if JSON flag is set, print JSON output
-	if writeJSON {
+	// if output flag is set, print JSON or YAML output
+	if outputFormat != "" {
 		k8sVersion, err := k8s.GetK8sVersion(r.client.Clientset)
 		if err != nil {
 			output.WriteError("Failed to get Kubernetes version: %s", err)
 		}
-		output.WriteJSON(verifier.JSONOutput{
+		structuredOutput := verifier.StructuredOutput{
 			K8sVersion: k8sVersion.String(),
 			Results:    outcomes,
-		})
+		}
+		switch strings.ToLower(outputFormat) {
+		case "json":
+			output.WriteJSON(structuredOutput)
+		case "yaml":
+			output.WriteYAML(structuredOutput)
+		default:
+			output.WriteError("Unknown output format: %s", outputFormat)
+		}
 		return
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	ltable "github.com/charmbracelet/lipgloss/table"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -82,4 +83,13 @@ func WriteJSON(output interface{}) {
 		WriteError("Failed to marshal JSON: %s", err)
 	}
 	fmt.Println(string(jsonOutput))
+}
+
+// WriteYAML writes the given output as a pretty printed YAML object to stdout
+func WriteYAML(output interface{}) {
+	yamlOutput, err := yaml.Marshal(output)
+	if err != nil {
+		WriteError("Failed to marshal YAML: %w", err)
+	}
+	fmt.Println(string(yamlOutput))
 }

--- a/internal/verifier/verifier.go
+++ b/internal/verifier/verifier.go
@@ -19,18 +19,18 @@ type Verifier struct {
 
 // Outcome is the result of an experiment
 type Outcome struct {
-	Experiment  string            `json:"experiment"`
-	Description string            `json:"description"`
-	Framework   string            `json:"framework"`
-	Tactic      string            `json:"tactic"`
-	Technique   string            `json:"technique"`
-	Result      map[string]string `json:"result"`
+	Experiment  string            `json:"experiment" yaml:"experiment"`
+	Description string            `json:"description" yaml:"description"`
+	Framework   string            `json:"framework" yaml:"framework"`
+	Tactic      string            `json:"tactic" yaml:"tactic"`
+	Technique   string            `json:"technique" yaml:"technique"`
+	Result      map[string]string `json:"result" yaml:"result"`
 }
 
-// JSONOutput is a pretty-printed JSON output of the verifier
-type JSONOutput struct {
-	K8sVersion string     `json:"k8s_version"`
-	Results    []*Outcome `json:"results"`
+// StructuredOutput is a pretty-printed JSON or YAML  output of the verifier
+type StructuredOutput struct {
+	K8sVersion string     `json:"k8s_version" yaml:"k8s_version"`
+	Results    []*Outcome `json:"results" yaml:"results"`
 }
 
 // New returns a new Verifier instance


### PR DESCRIPTION
Small PR which enables output of YAML as well as JSON from the verifiers.

```json
{
    "k8s_version": "v1.24.17-eks-3af4770",
    "results": [
        {
            "experiment": "run-privileged-container",
            "description": "This experiment attempts to run a privileged container in a namespace",
            "framework": "MITRE",
            "tactic": "Privilege Escalation",
            "technique": "Privileged Container",
            "result": {
                "HostNetwork": "success",
                "HostPID": "success",
                "Privileged": "success",
                "RunAsRoot": "success"
            }
        }
    ]
}
```

```yaml
k8s_version: v1.24.17-eks-3af4770
results:
- experiment: run-privileged-container
  description: This experiment attempts to run a privileged container in a namespace
  framework: MITRE
  tactic: Privilege Escalation
  technique: Privileged Container
  result:
    HostNetwork: success
    HostPID: success
    Privileged: success
    RunAsRoot: success
```