### PR TITLE
Reintroducing goreleaser for secops-chaos cli binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: make test
 
-  secops-chaos-cli:
+  release-secops-chaos-cli:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs: go-build-test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - "v*.*.*"
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   go-build-test:
     runs-on: ubuntu-latest
@@ -25,7 +28,27 @@ jobs:
     - name: Test
       run: make test
 
-  build:
+  secops-chaos-cli:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    needs: go-build-test
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.3'
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-docker:
     runs-on: ubuntu-latest
     needs: go-build-test
     permissions: write-all

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/secops-chaos
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.GitCommit={{.Commit}}"
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.Version={{.Version}}"
+      - "-X github.com/operantai/secops-chaos/cmd/secops-chaos/cmd.BuildDate={{ .Date }}"
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
We still need to include the CLI binaries in the release process.