### PR TITLE
Improvements to privileged container verifier

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -15,10 +15,10 @@ experiments:
 
 ## Available Experiments
 
-For a list of available experiments run `secops-chaos experiments`. You can then generate a example template to get started:
+For a list of available experiments run `secops-chaos experiment`. You can then generate a example template to get started:
 
 ```sh
-secops-chaos experiments snippets -e <experiment-type>
+secops-chaos experiment snippet -e <experiment-type>
 ```
 
 ## Implementing a new Experiment

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -15,13 +15,11 @@ experiments:
 
 ## Available Experiments
 
-| Type                                                  | Description                                                                                                                | Framework |
-|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|-----------|
-| [privileged-container](run-privileged-container.yaml) | This experiment attempts to run a privileged container in a namespace                                                      | MITRE     |
-| [host-path-mount](host-path-mount.yaml)               | This experiment attempts to mount a sensitive host filesystem path into a container                                        | MITRE     |
-| [cluster-admin-binding](cluster-admin-binding.yaml)   | This experiment attempts to create a container with the cluster-admin role binding attached                                | MITRE     |
-| [remote-execute-api](remote-execute-api.yaml)         | This experiment attempts to create a deployment with a configurable image and verifies based off of API calls to the image | MITRE     |
-| [execute-api](execute-api.yaml)                       | This experiment attempts to call a service with a payload                                                                  | MITRE     |
+For a list of available experiments run `secops-chaos experiments`. You can then generate a example template to get started:
+
+```sh
+secops-chaos experiments snippets -e <experiment-type>
+```
 
 ## Implementing a new Experiment
 

--- a/experiments/privileged-container.yaml
+++ b/experiments/privileged-container.yaml
@@ -4,9 +4,15 @@ experiments:
       type: privileged-container
       namespace: default
     parameters:
-      image: "alpine:latest"
-      command: [ "sh", "-c", "while true; do :; done"]
-      privileged: true
-      hostPid: true
-      hostNetwork: true
-      runAsRoot: true
+      experiment:
+        image: "alpine:latest"
+        command: [ "sh", "-c", "while true; do :; done"]
+        privileged: true
+        hostPid: true
+        hostNetwork: true
+        runAsRoot: true
+      verifier:
+        deployed: true
+        command:
+          - cat
+          - "/tmp/malicious-activity-log"

--- a/internal/experiments/experiments.go
+++ b/internal/experiments/experiments.go
@@ -87,7 +87,7 @@ func NewRunner(ctx context.Context, experimentFiles []string) *Runner {
 func (r *Runner) Run() {
 	for _, e := range r.experimentsConfig {
 		experiment := r.experiments[e.Metadata.Type]
-		output.WriteInfo("Running experiment %s\n", e.Metadata.Name)
+		output.WriteInfo("Running experiment %s", e.Metadata.Name)
 		if err := experiment.Run(r.ctx, r.client, e); err != nil {
 			output.WriteError("Experiment %s failed with error: %s", e.Metadata.Name, err)
 		}
@@ -146,7 +146,7 @@ func (r *Runner) RunVerifiers(outputFormat string) {
 // Cleanup cleans up all experiments in the Runner
 func (r *Runner) Cleanup() {
 	for _, e := range r.experimentsConfig {
-		output.WriteInfo("Cleaning up experiment %s\n", e.Metadata.Name)
+		output.WriteInfo("Cleaning up experiment %s", e.Metadata.Name)
 		experiment := r.experiments[e.Metadata.Type]
 		if err := experiment.Cleanup(r.ctx, r.client, e); err != nil {
 			output.WriteError("Experiment %s cleanup failed: %s", e.Metadata.Name, err)

--- a/internal/k8s/helpers.go
+++ b/internal/k8s/helpers.go
@@ -1,20 +1,46 @@
 package k8s
 
 import (
+	"context"
 	"errors"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ErrContainerNotFound is returned when a container is not found
 var ErrContainerNotFound = errors.New("container not found")
 
 // FindContainerByName returns a container by name from a list of containers
-func FindContainerByName(containers []corev1.Container, containerName string) (corev1.Container, error) {
+func (c *Client) FindContainerByName(containers []corev1.Container, containerName string) (corev1.Container, error) {
 	for _, container := range containers {
 		if container.Name == containerName {
 			return container, nil
 		}
 	}
 	return corev1.Container{}, ErrContainerNotFound
+}
+
+// GetDeploymentsPods gets the pods belonging to the provided deployment
+func (c *Client) GetDeploymentsPods(ctx context.Context, namespace string, deployment *appsv1.Deployment) ([]corev1.Pod, error) {
+	rsList, err := c.Clientset.AppsV1().ReplicaSets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: metav1.FormatLabelSelector(deployment.Spec.Selector),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var podsList []corev1.Pod
+	for _, rs := range rsList.Items {
+		pods, err := c.Clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+			LabelSelector: metav1.FormatLabelSelector(rs.Spec.Selector),
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, pod := range pods.Items {
+			podsList = append(podsList, pod)
+		}
+	}
+	return podsList, nil
 }

--- a/internal/k8s/helpers_test.go
+++ b/internal/k8s/helpers_test.go
@@ -49,7 +49,8 @@ func TestFindContainerByName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := FindContainerByName(test.containers, test.containerName)
+			client := Client{}
+			result, err := client.FindContainerByName(test.containers, test.containerName)
 
 			assert.Equal(t, test.expectedResult, result)
 			assert.Equal(t, test.expectedError, err)


### PR DESCRIPTION
```
┌──────────────────────────────┬────────────────────────────────┬─────────┬────────────────────┬────────────────────┬─────────────────┐
│Experiment                    │Description                     │Framework│Tactic              │Technique           │Result           │
├──────────────────────────────┼────────────────────────────────┼─────────┼────────────────────┼────────────────────┼─────────────────┤
│cncf-demo-privileged-container│Run a privileged container in...│MITRE    │Privilege Escalation│Privileged Container│Deployed: success│
│                              │                                │         │                    │                    │Command: fail    │
│                              │                                │         │                    │                    │                 │
└──────────────────────────────┴────────────────────────────────┴─────────┴────────────────────┴────────────────────┴─────────────────┘

```

Adds params for the verifier to run a command and check for a non-zero error code, and also checks if it's managed to deploy a privileged container