### PR TITLE
Fixing double error logging when unknown command provided

### DIFF
--- a/cmd/secops-chaos/cmd/root.go
+++ b/cmd/secops-chaos/cmd/root.go
@@ -4,7 +4,6 @@ Copyright 2023 Operant AI
 package cmd
 
 import (
-	"github.com/operantai/secops-chaos/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -18,8 +17,5 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		output.WriteError(err.Error())
-	}
+	_ = rootCmd.Execute()
 }


### PR DESCRIPTION
Noticed this as part of our demos today. We were getting double error logging when an unknown command was provided. 